### PR TITLE
fix: nan CTC loss

### DIFF
--- a/config/idn_config.yaml
+++ b/config/idn_config.yaml
@@ -8,10 +8,13 @@ dropout_rate: 0.5
 weight_decay: 0.00002
 lr: 0.001
 batch_size: 512
-t_length: 18
+t_length: 19
+gradient_clip_val: 1.0
 chars: [
     # NUMBERS
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
     # ALPHABETS
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    # Middle
+    '-'
 ]

--- a/config/kor_config.yaml
+++ b/config/kor_config.yaml
@@ -8,7 +8,7 @@ dropout_rate: 0.5
 weight_decay: 0.00002
 lr: 0.001
 batch_size: 256
-t_length: 18
+t_length: 19
 chars: [
     # NUMBERS
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',


### PR DESCRIPTION
Hi @kwon-evan,
Fix nan_loss in my trained process by:
- With image size [100, 50], number of timestep is 19. Then I have changed `t_length` from 18 to 19
- Missing bank character for idn_config, so I have added `-` to `chars`
- [This practice](https://discuss.pytorch.org/t/best-practices-to-solve-nan-ctc-loss/151913) shows `gradient_clip_val` might help to reduce nan CTC loss. I'm not sure if it is solution for nan loss issue, but it's nice to have.